### PR TITLE
chore: change export name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can use it to replace id's in API endpoints, username's in greetings or what
 Import `dynamicString` from `dynamic-string` .
 
 ```js
-import { dynamicTemplate } from 'dynamic-string'
+import { dynamicString } from 'dynamic-string'
 ```
 
 This [curried function](https://en.wikipedia.org/wiki/Currying) receives two positional arguments:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda'
 
-export const dynamicTemplate = R.curry(
+export const dynamicString = R.curry(
   (templateString: string, templateVariables: Record<string, any>) =>
     templateString.replace(/\${(.*?)}/g, (_, g) => templateVariables[g])
 )


### PR DESCRIPTION
# Description
Since @mdornseif  PR's changing the docs (#26) I couldn't help but to think that there was an underlying error with the export of the library which is named diferently then the library itself. 

This PR aims to fix this by keeping the libs language ubiquitous - which should be that hard for such a small lib :laughing: 


